### PR TITLE
Fix build action on master branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-    - users: actions/checkout@v2
+    - uses: actions/checkout@v2
     - name: Run Dockerfiler (with push)
       run: make run
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   build-images-with-push:
-    #if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,12 @@ jobs:
         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
 
   build-images-with-push:
-    if: github.ref == 'refs/heads/master'
+    #if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Docker login
+      run: docker login --username ${{ secrets.DOCKERHUB_USER }} --password ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: Run Dockerfiler (with push)
       run: make run
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,19 +3,24 @@ name: Build images
 on: push
 
 jobs:
-  build-images:
+  build-images-without-push:
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Run Dockerfiler (with push)
-      if: github.ref == 'refs/heads/master'
-      run: make run
+    - name: Run Dockerfiler (no push)
+      run: make dry-run
       env:
         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USER }}
         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-    - name: Run Dockerfiler (no push)
-      if: github.ref != 'refs/heads/master'
-      run: make dry-run
+
+  build-images-with-push:
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+    - users: actions/checkout@v2
+    - name: Run Dockerfiler (with push)
+      run: make run
       env:
         REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_USER }}
         REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
The "build images with push" GH Action was failing because it required `docker login`. This PR adds it and refactors so different jobs run on master/non-master branch.