### PR TITLE
Add protoc

### DIFF
--- a/Dockerfile/protoc/Dockerfile
+++ b/Dockerfile/protoc/Dockerfile
@@ -1,0 +1,29 @@
+FROM golang:1.15 AS builder
+ARG PROTOC_TAG
+ARG PROTOC_GEN_GO_TAG
+ARG PROTOC_GEN_GO_GRPC_TAG
+
+RUN apt-get update && apt-get install -y autoconf libtool unzip
+WORKDIR /src/protobuf
+RUN git clone https://github.com/protocolbuffers/protobuf . && git checkout $PROTOC_TAG
+
+# --disable-shared has it statically link libprotoc and libprotobuf
+RUN ./autogen.sh && ./configure --disable-shared --prefix /usr
+RUN make -j 3
+
+RUN make install
+
+# TODO: Once Go 1.16 is out of beta, use the newly supported `go install ...@...`
+#   cf. https://stackoverflow.com/a/64800215/349427
+RUN go mod init dummy_module # Required to `go get` with a version specified
+RUN go get github.com/golang/protobuf/protoc-gen-go@$PROTOC_GEN_GO_TAG
+RUN go get google.golang.org/grpc/cmd/protoc-gen-go-grpc@$PROTOC_GEN_GO_GRPC_TAG
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc
+
+# -------------
+
+FROM debian:bullseye-20210111-slim
+COPY --from=builder /usr/bin/protoc /usr/bin
+COPY --from=builder /go/bin/protoc-gen-go /usr/bin
+COPY --from=builder /go/bin/protoc-gen-go-grpc /usr/bin
+ENTRYPOINT ["protoc"]

--- a/Dockerfile/protoc/README.md
+++ b/Dockerfile/protoc/README.md
@@ -1,4 +1,4 @@
-# flake8
+# protoc
 
 This is an unofficial image for the protobuf compiler [protoc](https://github.com/protocolbuffers/protobuf), made available as `dockerizedtools/protoc` on [Docker Hub](https://hub.docker.com/r/dockerizedtools/protoc).
 

--- a/Dockerfile/protoc/README.md
+++ b/Dockerfile/protoc/README.md
@@ -1,0 +1,14 @@
+# flake8
+
+This is an unofficial image for the protobuf compiler [protoc](https://github.com/protocolbuffers/protobuf), made available as `dockerizedtools/protoc` on [Docker Hub](https://hub.docker.com/r/dockerizedtools/protoc).
+
+This image also contains the `protoc-gen-go` and `protoc-gen-go-grpc` plugins for use with gRPC in the Go language.
+
+Built from the Dockerfile at https://github.com/jbergknoff/dockerized-tools/blob/master/Dockerfile/protoc/Dockerfile
+
+## Usage
+
+```sh
+$ alias protoc='docker run --rm -v "$(pwd)":"$(pwd)" -w "$(pwd)" dockerizedtools/protoc:<version>'
+$ protoc stuff.proto
+```

--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,19 @@
       }
     }
   ],
+  "dockerizedtools/protoc": [
+    {
+      "type": "build",
+      "dockerfile_path": "Dockerfile/protoc/Dockerfile",
+      "tags": {
+        "3.14.0": {
+          "PROTOC_TAG": "v3.14.0",
+          "PROTOC_GEN_GO_TAG": "v1.4.3",
+          "PROTOC_GEN_GO_GRPC_TAG": "v1.1.0"
+        }
+      }
+    }
+  ],
   "dockerizedtools/terragrunt": [
     {
       "type": "build",


### PR DESCRIPTION
This adds the protobuf compiler [protoc](https://github.com/protocolbuffers/protobuf), including some plugins useful for gRPC development in Go.